### PR TITLE
taking full sha256 key for unique file name

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.8]
         os: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.8]
         os: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/quilt3distribute/file_utils.py
+++ b/quilt3distribute/file_utils.py
@@ -11,7 +11,7 @@ def create_unique_logical_key(physical_key: Union[str, Path]) -> str:
     pk = Path(physical_key).expanduser().resolve(strict=True)
 
     # Creat short hash from fully resolved physical key
-    short_hash = hashlib.sha256(str(pk).encode("utf-8")).hexdigest()[:8]
+    short_hash = hashlib.sha256(str(pk).encode("utf-8")).hexdigest()
 
     # Return the unique logical key
     return f"{short_hash}_{pk.name}"

--- a/quilt3distribute/tests/test_file_utils.py
+++ b/quilt3distribute/tests/test_file_utils.py
@@ -18,8 +18,8 @@ def test_create_unique_logical_key(example_csv):
     path_created_logical_key = file_utils.create_unique_logical_key(example_csv)
     str_created_logical_key = file_utils.create_unique_logical_key(str(example_csv))
 
-    # Should be 8 characters of hex followed by the filename
-    regexp = re.compile("[a-z0-9]{8}_example.csv")
+    # Should be a hex string followed by the filename
+    regexp = re.compile("[a-z0-9]_example.csv")
 
     # Assert that both generated logical keys match the pattern
     # We can't just use a predetermined hash here because depending on the testing machine, the fully resolved

--- a/quilt3distribute/tests/test_file_utils.py
+++ b/quilt3distribute/tests/test_file_utils.py
@@ -24,6 +24,8 @@ def test_create_unique_logical_key(example_csv):
     # Assert that both generated logical keys match the pattern
     # We can't just use a predetermined hash here because depending on the testing machine, the fully resolved
     # filepath may be different
+    print(path_created_logical_key)
+    print(str_created_logical_key)
     assert regexp.match(path_created_logical_key)
     assert regexp.match(str_created_logical_key)
 

--- a/quilt3distribute/tests/test_file_utils.py
+++ b/quilt3distribute/tests/test_file_utils.py
@@ -18,8 +18,8 @@ def test_create_unique_logical_key(example_csv):
     path_created_logical_key = file_utils.create_unique_logical_key(example_csv)
     str_created_logical_key = file_utils.create_unique_logical_key(str(example_csv))
 
-    # Should be a hex string followed by the filename
-    regexp = re.compile("[a-z0-9]_example.csv")
+    # Should be a 64 digit hex string followed by the filename
+    regexp = re.compile("[a-z0-9]{64}_example.csv")
 
     # Assert that both generated logical keys match the pattern
     # We can't just use a predetermined hash here because depending on the testing machine, the fully resolved

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ test_requirements = [
     "pytest",
     "pytest-cov",
     "pytest-raises",
-    "tifffile==0.15.1",
+    "tifffile",
 ]
 
 setup_requirements = [


### PR DESCRIPTION
Taking first 8 digits of the sha256 key is not enough to avoid conflicting filenames, when the dataset is huge. 